### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,4 +1,6 @@
 name: Node.js CI
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Zavierazo/vtesdecks-front/security/code-scanning/4](https://github.com/Zavierazo/vtesdecks-front/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with the repository contents and uses secrets for Sentry integration. Therefore, the `contents: read` permission is sufficient for most steps, and no additional permissions are required unless explicitly needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions specifically for that job. In this case, adding it at the root level is recommended for simplicity and consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
