### PR TITLE
Show tutorial desktop/tablet warning only on small screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vtes-decks-front",
-  "version": "2.75.0",
+  "version": "2.75.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vtes-decks-front",
-      "version": "2.75.0",
+      "version": "2.75.1",
       "dependencies": {
         "@angular-slider/ngx-slider": "^22.0.0",
         "@angular/cdk": "^22.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtes-decks-front",
-  "version": "2.75.0",
+  "version": "2.75.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/modules/tutorial/narrator/tutorial-narrator.component.html
+++ b/src/app/modules/tutorial/narrator/tutorial-narrator.component.html
@@ -29,6 +29,14 @@
     </span>
   }
 
+  @if (warningKey$(); as warningKey) {
+    <p
+      class="t-narrator-warning"
+      data-cy="tutorial-narrator-warning"
+      [innerHTML]="t(warningKey) | tutorialEmphasis"
+    ></p>
+  }
+
   <p
     class="t-narrator-text"
     data-cy="tutorial-narrator-text"

--- a/src/app/modules/tutorial/narrator/tutorial-narrator.component.scss
+++ b/src/app/modules/tutorial/narrator/tutorial-narrator.component.scss
@@ -37,6 +37,17 @@
   align-self: flex-start;
 }
 
+.t-narrator-warning {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--bs-warning-border-subtle, var(--bs-border-color));
+  background: var(--bs-warning-bg-subtle, rgba(255, 193, 7, 0.15));
+  color: var(--bs-warning-text-emphasis, var(--bs-body-color));
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
 .t-narrator-text {
   margin: 0;
   font-size: 1rem;

--- a/src/app/modules/tutorial/narrator/tutorial-narrator.component.ts
+++ b/src/app/modules/tutorial/narrator/tutorial-narrator.component.ts
@@ -4,8 +4,10 @@ import {
   computed,
   inject,
 } from '@angular/core'
+import { toSignal } from '@angular/core/rxjs-interop'
 import { RouterLink } from '@angular/router'
 import { TranslocoDirective } from '@jsverse/transloco'
+import { MediaService } from '@services'
 import { TutorialStore } from '../state/tutorial.store'
 import { tutorialStepTextKey } from '../state/tutorial-script.model'
 import { TutorialEmphasisPipe } from '../shared/tutorial-emphasis.pipe'
@@ -20,6 +22,10 @@ import { TutorialEmphasisPipe } from '../shared/tutorial-emphasis.pipe'
 })
 export class TutorialNarratorComponent {
   readonly store = inject(TutorialStore)
+  private readonly isMobile$ = toSignal(
+    inject(MediaService).observeMobile(),
+    { initialValue: false },
+  )
 
   readonly chapterNumber$ = computed(
     () => this.store.progress$().chapterIndex + 1,
@@ -31,6 +37,16 @@ export class TutorialNarratorComponent {
       this.store.currentChapter$().id,
       this.store.currentStep$(),
     ),
+  )
+
+  /**
+   * Small-screen-only warning key, shown when the step opts in via
+   * `mobileWarning` and the viewport is a phone (desktop/tablet skip it).
+   */
+  readonly warningKey$ = computed(() =>
+    this.store.currentStep$().mobileWarning === true && this.isMobile$()
+      ? `${this.textKey$()}Warning`
+      : undefined,
   )
 
   readonly advance$ = computed(() => this.store.currentStep$().advance)

--- a/src/app/modules/tutorial/state/tutorial-script.data.ts
+++ b/src/app/modules/tutorial/state/tutorial-script.data.ts
@@ -462,7 +462,7 @@ export const TUTORIAL_SCRIPT: TutorialChapter[] = [
     icon: 'bi-moon-stars-fill',
     initialBoard: START_BOARD(),
     steps: [
-      { id: 's0', advance: { type: 'next' } },
+      { id: 's0', advance: { type: 'next' }, mobileWarning: true },
       { id: 's1', advance: { type: 'next' } },
       { id: 's2', advance: { type: 'next' }, highlight: ['pool:you'] },
       { id: 's3', advance: { type: 'next' }, highlight: ['pool:rival'] },

--- a/src/app/modules/tutorial/state/tutorial-script.model.ts
+++ b/src/app/modules/tutorial/state/tutorial-script.model.ts
@@ -122,6 +122,12 @@ export interface TutorialStep {
   highlight?: TutorialTargetId[]
   /** Shows a "rival's turn" treatment on the narrator. */
   rivalThinking?: boolean
+  /**
+   * Shows an extra warning above the narration only on small (phone)
+   * screens, read from the `<chapter>.<step>Warning` key. Used to nudge
+   * phone users toward a desktop or tablet without cluttering larger screens.
+   */
+  mobileWarning?: boolean
   /** Temporarily shows the player's uncontrolled cards face up. */
   revealUncontrolled?: boolean
   /** Shows the combat tracker (round number + current combat stage). */

--- a/src/assets/i18n/tutorial/en.json
+++ b/src/assets/i18n/tutorial/en.json
@@ -68,7 +68,8 @@
     "ch13": { "title": "The oust" }
   },
   "ch1": {
-    "s0": "Quick note before we start: this tutorial works best on a desktop or tablet, where the whole table fits on screen. On a small phone it still runs, but the play regions get cramped. Also, it simplifies a few rules (intercept, some combat details and edge cases); the rulebook is the final word.",
+    "s0": "Before we start: this tutorial simplifies a few rules (intercept, some combat details and edge cases); the rulebook is the final word.",
+    "s0Warning": "Quick note: this tutorial works best on a desktop or tablet, where the whole table fits on screen. On a small phone it still runs, but the play regions get cramped.",
     "s1": "Welcome! In Vampire: The Eternal Struggle (VTES) you are a Methuselah, an ancient vampire. You do not fight directly: you control younger vampires and send them to do your work.",
     "s2": "This is your POOL: 30 blood counters. Pool is both your life and your money. You spend it to bring vampires into play, and if you run out you lose.",
     "s3": "This is your rival's pool. In a full game 4 or 5 players sit in a circle. The player on your left is your PREY and the one on your right is your PREDATOR. In this two player demo your rival is both.",

--- a/src/assets/i18n/tutorial/es.json
+++ b/src/assets/i18n/tutorial/es.json
@@ -94,7 +94,8 @@
     }
   },
   "ch1": {
-    "s0": "Un apunte antes de empezar: este tutorial se disfruta mejor en ordenador o tableta, donde toda la mesa cabe en la pantalla. En un móvil pequeño también funciona, pero las regiones de juego quedan apretadas. Además, simplifica algunas reglas (intercepción, ciertos detalles del combate y casos especiales); el reglamento tiene la última palabra.",
+    "s0": "Antes de empezar: este tutorial simplifica algunas reglas (intercepción, ciertos detalles del combate y casos especiales); el reglamento tiene la última palabra.",
+    "s0Warning": "Un apunte: este tutorial se disfruta mejor en ordenador o tableta, donde toda la mesa cabe en la pantalla. En un móvil pequeño también funciona, pero las regiones de juego quedan apretadas.",
     "s1": "¡Bienvenido! En Vampire: The Eternal Struggle (VTES) eres un Matusalén, un vampiro ancestral. No luchas directamente: controlas vampiros más jóvenes y los envías a hacer el trabajo.",
     "s2": "Esta es tu RESERVA: 30 contadores de sangre. La reserva es tu vida y tu dinero a la vez. La gastas para poner vampiros en juego, y si se agota, pierdes.",
     "s3": "Esta es la reserva de tu rival. En una partida completa juegan 4 o 5 jugadores en círculo. El jugador a tu izquierda es tu PRESA y el de tu derecha, tu DEPREDADOR. En esta demo de dos jugadores tu rival es ambos.",

--- a/src/assets/i18n/tutorial/fr.json
+++ b/src/assets/i18n/tutorial/fr.json
@@ -94,7 +94,8 @@
     }
   },
   "ch1": {
-    "s0": "Une précision avant de commencer : ce tutoriel se joue mieux sur ordinateur ou tablette, où toute la table tient à l'écran. Sur un petit téléphone il fonctionne aussi, mais les régions de jeu deviennent à l'étroit. De plus, il simplifie quelques règles (interception, certains détails du combat et cas particuliers) ; le livre de règles a le dernier mot.",
+    "s0": "Avant de commencer : ce tutoriel simplifie quelques règles (interception, certains détails du combat et cas particuliers) ; le livre de règles a le dernier mot.",
+    "s0Warning": "Une précision : ce tutoriel se joue mieux sur ordinateur ou tablette, où toute la table tient à l'écran. Sur un petit téléphone il fonctionne aussi, mais les régions de jeu deviennent à l'étroit.",
     "s1": "Bienvenue ! Dans Vampire: The Eternal Struggle (VTES), vous êtes un Mathusalem, un vampire ancestral. Vous ne combattez pas directement : vous contrôlez des vampires plus jeunes et les envoyez agir pour vous.",
     "s2": "Voici votre RÉSERVE : 30 compteurs de sang. La réserve est à la fois votre vie et votre argent. Vous la dépensez pour mettre des vampires en jeu, et si elle tombe à zéro, vous perdez.",
     "s3": "Voici la réserve de votre rival. Dans une vraie partie, 4 ou 5 joueurs sont assis en cercle. Le joueur à votre gauche est votre PROIE et celui à votre droite votre PRÉDATEUR. Dans cette démo à deux, votre rival est les deux.",

--- a/src/assets/i18n/tutorial/pt.json
+++ b/src/assets/i18n/tutorial/pt.json
@@ -94,7 +94,8 @@
     }
   },
   "ch1": {
-    "s0": "Uma observação antes de começar: este tutorial funciona melhor em computador ou tablet, onde a mesa inteira cabe na tela. Em um celular pequeno também funciona, mas as regiões de jogo ficam apertadas. Além disso, ele simplifica algumas regras (interceptação, certos detalhes de combate e casos especiais); o livro de regras é a palavra final.",
+    "s0": "Antes de começar: este tutorial simplifica algumas regras (interceptação, certos detalhes de combate e casos especiais); o livro de regras é a palavra final.",
+    "s0Warning": "Uma observação: este tutorial funciona melhor em computador ou tablet, onde a mesa inteira cabe na tela. Em um celular pequeno também funciona, mas as regiões de jogo ficam apertadas.",
     "s1": "Bem-vindo! Em Vampire: The Eternal Struggle (VTES) você é um Matusalém, um vampiro ancestral. Você não luta diretamente: controla vampiros mais jovens e os envia para fazer o trabalho.",
     "s2": "Esta é a sua RESERVA: 30 marcadores de sangue. A reserva é sua vida e seu dinheiro ao mesmo tempo. Você a gasta para colocar vampiros em jogo, e se ela acabar você perde.",
     "s3": "Esta é a reserva do seu rival. Em uma partida completa, 4 ou 5 jogadores sentam em círculo. O jogador à sua esquerda é sua PRESA e o à direita, seu PREDADOR. Nesta demo de dois jogadores, seu rival é os dois.",


### PR DESCRIPTION
Split the tutorial intro (ch1.s0) so the "play on a desktop or tablet"
note becomes a separate `s0Warning` key that the narrator renders only
on phone-sized viewports, while the rules-simplification note stays on
every screen. Adds an opt-in `mobileWarning` step flag and reads the
viewport via MediaService.observeMobile().

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014U1UPSJV3hWE6oejt6rU2t