### PR TITLE
fix(admin): make feature flags panel responsive on mobile

### DIFF
--- a/src/app/modules/admin/feature-flags/feature-flags.component.html
+++ b/src/app/modules/admin/feature-flags/feature-flags.component.html
@@ -2,13 +2,13 @@
   <h1 class="mb-1">{{ t('feature_flags_title') }}</h1>
   <p class="text-muted">{{ t('feature_flags_hint') }}</p>
   <div class="table-responsive">
-    <table class="table align-middle">
+    <table class="table align-middle feature-flags-table">
       <thead>
         <tr>
           <th scope="col">{{ t('key') }}</th>
           <th scope="col">{{ t('type') }}</th>
           <th scope="col" class="d-none d-md-table-cell">{{ t('description') }}</th>
-          <th scope="col" class="w-50">{{ t('value') }}</th>
+          <th scope="col" class="value-col">{{ t('value') }}</th>
         </tr>
       </thead>
       <tbody>
@@ -17,7 +17,7 @@
           <td><code>{{ flag.key }}</code></td>
           <td><span class="badge text-bg-secondary">{{ flag.type }}</span></td>
           <td class="d-none d-md-table-cell">{{ flag.description }}</td>
-          <td>
+          <td class="value-col">
             @switch (flag.type) {
             @case ('BOOLEAN') {
             <div class="form-check form-switch">

--- a/src/app/modules/admin/feature-flags/feature-flags.component.scss
+++ b/src/app/modules/admin/feature-flags/feature-flags.component.scss
@@ -1,0 +1,49 @@
+:host {
+  display: block;
+}
+
+.value-col {
+  width: 50%;
+}
+
+// Stack the table into cards on small screens so the inputs get the full
+// available width instead of being squeezed into a narrow table cell.
+@media (max-width: 767.98px) {
+  .feature-flags-table {
+    thead {
+      display: none;
+    }
+
+    tbody,
+    tr,
+    td {
+      display: block;
+      width: 100%;
+    }
+
+    tr {
+      border: 1px solid var(--bs-border-color);
+      border-radius: 0.5rem;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1rem;
+    }
+
+    td {
+      border: 0;
+      padding: 0.25rem 0;
+
+      &.value-col {
+        width: 100%;
+      }
+    }
+  }
+
+  // Allow the input + action buttons to wrap onto their own lines when the
+  // card is too narrow to fit them side by side.
+  .input-group {
+    .form-control {
+      flex: 1 1 auto;
+      min-width: 8rem;
+    }
+  }
+}

--- a/src/app/modules/admin/feature-flags/feature-flags.component.ts
+++ b/src/app/modules/admin/feature-flags/feature-flags.component.ts
@@ -17,6 +17,7 @@ import { Observable } from 'rxjs'
 @Component({
   selector: 'app-feature-flags',
   templateUrl: './feature-flags.component.html',
+  styleUrl: './feature-flags.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [TranslocoDirective, AsyncPipe],
 })


### PR DESCRIPTION
The feature flags table forced a fixed 50% value column and kept the
input-groups on a single row, so the text/list inputs and their action
buttons were cramped and overflowed horizontally on small screens.

Stack the table into per-flag cards below the md breakpoint so each
value input gets the full width, and let input-group controls wrap
gracefully. The desktop table layout is unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CBQ9V6yquTFk8bSHoJxUE1